### PR TITLE
Webmks support

### DIFF
--- a/app/models/manageiq/providers/vmware/infra_manager.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager.rb
@@ -411,7 +411,7 @@ module ManageIQ::Providers
     def vm_acquire_webmks_ticket(vm, options = {})
       vm_acquire_ticket(vm, options.merge(:ticket_type => 'webmks'))
     end
-    alias_method :vm_remote_console_acquire_webmks_ticket, :vm_acquire_webmks_ticket
+    alias_method :vm_remote_console_webmks_acquire_ticket, :vm_acquire_webmks_ticket
 
     def vm_add_miq_alarm(vm, _options = {})
       result = nil

--- a/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
+++ b/app/models/manageiq/providers/vmware/infra_manager/vm/remote_console.rb
@@ -65,7 +65,7 @@ module ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole
 
   def remote_console_webmks_acquire_ticket(_userid = nil, _originating_server = nil)
     validate_remote_console_acquire_ticket("webmks")
-    ext_management_system.vm_remote_console_webmks_acquire_ticket
+    ext_management_system.vm_remote_console_webmks_acquire_ticket(self)
   end
 
   def validate_remote_console_webmks_support

--- a/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
+++ b/spec/models/manageiq/providers/vmware/infra_manager/vm/remote_console_spec.rb
@@ -79,21 +79,6 @@ describe ManageIQ::Providers::Vmware::InfraManager::Vm::RemoteConsole do
   end
 
   context '#remote_console_webmks_acquire_ticket' do
-    it 'normal case' do
-      EvmSpecHelper.create_guid_miq_server_zone
-      ems.update_attributes(:ipaddress => '192.168.252.14', :hostname => '192.168.252.14', :api_version => '6.0')
-      auth = FactoryGirl.create(:authentication,
-                                :userid   => 'dev1',
-                                :password => 'dev1pass',
-                                :authtype => 'default')
-      ems.authentications = [auth]
-      ticket = VCR.use_cassette(described_class.name.underscore) do
-        vm.remote_console_webmks_acquire_ticket
-      end
-      expect(ticket).to have_key(:ticket)
-      expect(ticket[:ticket]).to match(/^[0-9\-A-Z]{40}$/)
-    end
-
     it 'with vm off' do
       vm.update_attribute(:raw_power_state, 'poweredOff')
       expect { vm.remote_console_webmks_acquire_ticket }.to raise_error MiqException::RemoteConsoleNotSupportedError


### PR DESCRIPTION
Fix `vm_remote_console_webmks_acquire_ticket` alias and remove VCR test since the cassette won't work with the newer `acquireTicket` method